### PR TITLE
Use correct state value in option element

### DIFF
--- a/python/elections/templates/address_form.html
+++ b/python/elections/templates/address_form.html
@@ -18,7 +18,7 @@
       <select name="state" id="state-field">
         <option></option>
         {% for state in states %}
-          <option value=state>{{ state }}</option>
+          <option value="{{ state }}">{{ state }}</option>
         {% endfor %}
       </select>
       <label for="zip-field">Zip: </label>


### PR DESCRIPTION
The value was literally `"state"` in the generated html.