### PR TITLE
Update Python Practical Template

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -12,3 +12,4 @@ htmlcov/
 dist/
 build/
 *.egg-info/
+dw_venv/

--- a/python/README.md
+++ b/python/README.md
@@ -1,18 +1,33 @@
 # Upcoming Elections Practical
 Full instructions for installing Flask can be found [here](http://flask.pocoo.org/docs/1.0/installation/).
 
-Otherwise:
+## Set up Python3 env
 
 ```
+pip install --upgrade virtualenv
+
+# Create a virtual env in Python3 called `dw_practical`
+virtualenv --python=python3 dw_practical
+
+# Enter the virtual env -- you'll need to do this every time to run anything
+source ./dw_practical/bin/activate
+
+# Install the requirements
 pip3 install -r requirements.txt
+
+# If you want to exit the virtualenv when you're done, you can use the `deactivate` command by itself.
 ```
 If you don't have `pip` installed, follow the instructions [here](https://pip.pypa.io/en/stable/installing/)
+
 
 ## Running
 
 From the `dw-practical-upcoming-elections/python` directory, run the following:
 
 ```
+# If you haven't done this in this terminal yet
+source ./dw_practical/bin/activate
+
 export FLASK_APP=elections
 export FLASK_ENV=development
 flask run
@@ -21,6 +36,9 @@ flask run
 ## Testing
 
 ```
+# If you haven't done this in this terminal yet
+source ./dw_practical/bin/activate
+
 pytest
 ```
 
@@ -39,13 +57,3 @@ as was previously allowed.
 
 If setting up or running Python 3 causes you any issues, please reach out. Getting things running
 is not part of the evaluation and we'll be happy to help troubleshoot without judgement.
-
-### After the practical
-If you run other personal projects in Python 2, you may want to re-install the requirements in the
-`requirements.txt` file with Python 2 after you are done with this practical to avoid unexpected
-issues.
-
-```
-# Note `pip` instead of `pip3` here
-pip install -r requirements.txt
-```

--- a/python/README.md
+++ b/python/README.md
@@ -6,11 +6,11 @@ Full instructions for installing Flask can be found [here](http://flask.pocoo.or
 ```
 pip install --upgrade virtualenv
 
-# Create a virtual env in Python3 called `dw_practical`
-virtualenv --python=python3 dw_practical
+# Create a virtual env in Python3 called `dw_venv`
+virtualenv --python=python3 dw_venv
 
 # Enter the virtual env -- you'll need to do this every time to run anything
-source ./dw_practical/bin/activate
+source ./dw_venv/bin/activate
 
 # Install the requirements
 pip3 install -r requirements.txt
@@ -26,7 +26,7 @@ From the `dw-practical-upcoming-elections/python` directory, run the following:
 
 ```
 # If you haven't done this in this terminal yet
-source ./dw_practical/bin/activate
+source ./dw_venv/bin/activate
 
 export FLASK_APP=elections
 export FLASK_ENV=development
@@ -37,7 +37,7 @@ flask run
 
 ```
 # If you haven't done this in this terminal yet
-source ./dw_practical/bin/activate
+source ./dw_venv/bin/activate
 
 pytest
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -1,12 +1,16 @@
 # Upcoming Elections Practical
-Full instructions for installing Flask can be found [here](http://flask.pocoo.org/docs/1.0/installation/)
-otherwise:
+Full instructions for installing Flask can be found [here](http://flask.pocoo.org/docs/1.0/installation/).
+
+Otherwise:
 
 ```
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 ```
+If you don't have `pip` installed, follow the instructions [here](https://pip.pypa.io/en/stable/installing/)
 
 ## Running
+
+From the `dw-practical-upcoming-elections/python` directory, run the following:
 
 ```
 export FLASK_APP=elections
@@ -18,4 +22,30 @@ flask run
 
 ```
 pytest
+```
+
+## Note on Python 3
+You can skip this section if you're sure your computer is configured to run Python 3 by default.
+
+The code is set up to run with Python 3. This should take no extra configuration on your part
+as long as you have Python 3 installed, even if it is not your default. You can check that your
+computer has it by running `which python3`. If you don't have it, see the instructions
+[here](https://realpython.com/installing-python/).
+
+If you are familiar with Python 2 but haven't worked much with Python 3, you shouldn't notice
+much of a difference. Likely the only notable difference you'll run into in this project is when
+debugging - `print` has to be called like `print("Something")` rather than`print "Something"`
+as was previously allowed.
+
+If setting up or running Python 3 causes you any issues, please reach out. Getting things running
+is not part of the evaluation and we'll be happy to help troubleshoot without judgement.
+
+### After the practical
+If you run other personal projects in Python 2, you may want to re-install the requirements in the
+`requirements.txt` file with Python 2 after you are done with this practical to avoid unexpected
+issues.
+
+```
+# Note `pip` instead of `pip3` here
+pip install -r requirements.txt
 ```

--- a/python/elections/__init__.py
+++ b/python/elections/__init__.py
@@ -1,7 +1,9 @@
 import os
-
+import sys
 from flask import Flask
 
+if sys.version_info[0] < 3:
+    raise Exception("Must be using Python 3")
 
 def create_app(test_config=None):
     # create and configure the app

--- a/python/elections/templates/election_results.html
+++ b/python/elections/templates/election_results.html
@@ -1,0 +1,1 @@
+[TODO Placeholder results page]

--- a/python/elections/test/__init__.py
+++ b/python/elections/test/__init__.py
@@ -1,0 +1,5 @@
+import sys
+print(sys.version_info[0])
+raise Exception
+if sys.version_info[0] < 3:
+    raise Exception("Must be using Python 3")

--- a/python/elections/upcoming.py
+++ b/python/elections/upcoming.py
@@ -1,5 +1,3 @@
-import functools
-
 from elections.us_states import postal_abbreviations
 
 from flask import (
@@ -9,7 +7,8 @@ from flask import (
 bp = Blueprint('address_form', __name__, url_prefix='/')
 
 
-@bp.route('/', methods=('GET', 'POST'))
+@bp.route('/search', methods=('GET', 'POST'))
+@bp.route('/')
 def search():
     """Take in an address."""
     if request.method == 'POST':

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,2 @@
-Flask==1.0.2
+Flask==1.1.1
 pytest==4.3.0


### PR DESCRIPTION
Add instructions for running the practical in Python 3 to ensure consistency across machines since Python 2 End of Life was 1/1/2020.

Also add two small fixes so code runs without errors out of the box.